### PR TITLE
Bugfix Responsive for login component

### DIFF
--- a/src/components/login/index.js
+++ b/src/components/login/index.js
@@ -24,16 +24,16 @@ const LoginComponent = () => {
             <br />
             <br />
             <div className={styles.containerRow}>
-                {/* <div className={styles.containerCol}> */}
-                <p className={styles.smallText}>ยังไม่เป็นสมาชิก?</p>
-                {/* <div className={styles.containerRow}> */}
-                <div>
-                    <button className={styles.buttonWhile}>สมัครสมาชิก</button>
-                    <button className={styles.buttonBlue}>สมัครด้วย Facebook</button>
-                    <button className={styles.buttonLine}>สมัครด้วย Line</button>
+                <div className={styles.containerCol}>
+                    <p className={styles.smallText}>ยังไม่เป็นสมาชิก?</p>
+                    <div className={styles.containerRow}>
+                        <div>
+                            <button className={styles.buttonWhile}>สมัครสมาชิก</button>
+                            <button className={styles.buttonBlue}>สมัครด้วย Facebook</button>
+                            <button className={styles.buttonLine}>สมัครด้วย Line</button>
+                        </div>
+                    </div>
                 </div>
-                {/* </div> */}
-                {/* </div> */}
             </div>
 
         </>

--- a/src/components/member-login/index.module.scss
+++ b/src/components/member-login/index.module.scss
@@ -1,16 +1,21 @@
 @import "../../variables";
 
 .container {
-
+    
     margin:  50px auto 0px auto;
-
+    
     display: flex;
     flex-direction: column;
-
-    // width: 450px;
+    
+    @media screen and (min-width: 768px){
+        width: 450px;
+    }
+    @media screen and (max-width: 767px){
+        width: 100%;
+    }
 
     h2 {
-        margin: 0px 0px 20px 10px;
+        margin: 5px 0px 20px 10px;
     }
     
 }


### PR DESCRIPTION
Changelog
- fix SCSS of  'login' component, affect `/member-login` and `/login`
  - `width: 100%` where <= 767px
  - `width: 450px` where >= 768px 

_Figure 1 - '/member-login' width 320px_
![image](https://user-images.githubusercontent.com/32980495/95556222-2aaa0380-0a3d-11eb-9206-980daf3f0c37.png)


_Figure 2 - '/member-login' width 1000px_
![image](https://user-images.githubusercontent.com/32980495/95556131-051cfa00-0a3d-11eb-8843-c5798018e13c.png)
